### PR TITLE
utility関数を別ディレクトリに切り出した

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,13 @@ OBJS_DIR := ./objs
 MAIN_SRC := main.c
 MAIN_SRC := $(addprefix $(SRCS_DIR)/, $(MAIN_SRC))
 
+# utils files
+UTILS_DIR := utils
+UTILS_SRCS := perror_exit.c
+
+UTILS_DIR := $(addprefix $(SRCS_DIR)/, $(UTILS_DIR))
+UTILS_SRCS := $(addprefix $(UTILS_DIR)/, $(UTILS_SRCS))
+
 # executor files
 EXEC_DIR := exec
 EXEC_SRCS := exec.c
@@ -26,7 +33,6 @@ TOKENIZER_DIR := tokenizer
 TOKENIZER_SRCS := tokenizer.c \
 				  tokenizer_helper.c \
 				  tokenizer_utils.c \
-				  utils.c \
 
 TOKENIZER_DIR := $(addprefix $(SRCS_DIR)/, $(TOKENIZER_DIR))
 TOKENIZER_SRCS := $(addprefix $(TOKENIZER_DIR)/, $(TOKENIZER_SRCS))

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -1,4 +1,5 @@
 #include "exec.h"
+#include "utils.h"
 extern char **environ;
 
 size_t	count_argc(t_node *commands)

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -1,4 +1,5 @@
 #include "parser.h"
+#include "utils.h"
 
 char	*node_type2str(t_node_type type)
 {

--- a/srcs/tokenizer/tokenizer.c
+++ b/srcs/tokenizer/tokenizer.c
@@ -1,4 +1,5 @@
 #include "tokenizer.h"
+#include "utils.h"
 
 static t_token	*tokenize_operator(t_token *cur, char **cur_ch);
 static t_token	*tokenize_quotes(t_token *cur, char **cur_ch, char quote_ch);

--- a/srcs/tokenizer/tokenizer.h
+++ b/srcs/tokenizer/tokenizer.h
@@ -38,6 +38,4 @@ void	dealloc_token(t_token *head);
 char	*token_type2str(t_token_type type);
 void	print_token(t_token *token);
 
-void	perror_exit(char *func_name);
-
 #endif

--- a/srcs/utils/perror_exit.c
+++ b/srcs/utils/perror_exit.c
@@ -1,4 +1,4 @@
-#include "tokenizer.h"
+#include "utils.h"
 
 void	perror_exit(char *func_name)
 {

--- a/srcs/utils/utils.h
+++ b/srcs/utils/utils.h
@@ -1,0 +1,8 @@
+#ifndef UTILS_H
+# define UTILS_H
+# include <stdio.h>
+# include <stdlib.h>
+
+void	perror_exit(char *func_name);
+
+#endif


### PR DESCRIPTION
### 概要
- 初期の状態でtokenizerのutilsに入っていた、perror_exitなどのutility関数を他のパッケージからも使えるようにするために、別ディレクトリに切り出した。