### PR TITLE
env nodeのvalueにNULLを許容する形に仕様変更

### DIFF
--- a/srcs/env.h
+++ b/srcs/env.h
@@ -18,6 +18,7 @@ typedef struct s_env		t_env;
 struct s_env
 {
 	size_t		size;
+	size_t		export_size;
 	t_env_node	*head;
 	t_env_node	*tail;
 	int			status;

--- a/srcs/env.h
+++ b/srcs/env.h
@@ -35,7 +35,6 @@ bool		env_is_name_valid(char *name);
 t_env_node	*env_find_node(t_env *env, char *name);
 char		*make_pair_str(char *name, char *value);
 char		**env_list_to_environ(t_env *env);
-void		env_print(t_env *env);
 
 // env_add.c
 int			env_set(t_env *env, char *name, char *value, int overwrite);

--- a/srcs/env_add.c
+++ b/srcs/env_add.c
@@ -1,7 +1,7 @@
 #include "env.h"
 
 static void	env_add_new_env_node(t_env *env, char *name, char *value);
-static void	env_replace_value(t_env_node *target, char *value);
+static void	env_replace_value(t_env *env, t_env_node *target, char *value);
 
 int	env_set(t_env *env, char *name, char *value, int overwrite)
 {
@@ -14,7 +14,7 @@ int	env_set(t_env *env, char *name, char *value, int overwrite)
 	else if (overwrite == 0)
 		return (0);
 	if (target != NULL)
-		env_replace_value(target, value);
+		env_replace_value(env, target, value);
 	else
 		env_add_new_env_node(env, name, value);
 	return (0);
@@ -25,13 +25,17 @@ static void	env_add_new_env_node(t_env *env, char *name, char *value)
 	t_env_node	*node;
 	t_env_node	tmp;
 
+	// TODO: add name validation
 	tmp.name = ft_strdup(name);
+	if (tmp.name == NULL)
+		err_fatal(errno);
+	tmp.value = NULL;
 	if (value != NULL)
+	{
 		tmp.value = ft_strdup(value);
-	else
-		tmp.value = ft_strdup("");
-	if (tmp.name == NULL || tmp.value == NULL)
-		ft_fatal("malloc");
+		if (tmp.value == NULL)
+			err_fatal(errno);
+	}
 	tmp.pair_str = make_pair_str(name, value);
 	node = new_env_node(tmp.name, tmp.value, tmp.pair_str);
 	if (env->head == NULL)
@@ -40,22 +44,27 @@ static void	env_add_new_env_node(t_env *env, char *name, char *value)
 		env->tail->next = node;
 	env->tail = node;
 	env->size++;
+	if (value != NULL)
+		env->export_size++;
 }
 
-static void	env_replace_value(t_env_node *target, char *value)
+static void	env_replace_value(t_env *env, t_env_node *target, char *value)
 {
 	char	*dup_value;
 	char	*pair_str;
 
+	dup_value = NULL;
 	if (value != NULL)
+	{
 		dup_value = ft_strdup(value);
-	else
-		dup_value = ft_strdup("");
-	if (dup_value == NULL)
-		ft_fatal("malloc");
+		if (dup_value == NULL)
+			err_fatal(errno);
+	}
 	pair_str = make_pair_str(target->name, value);
 	free(target->value);
 	free(target->pair_str);
 	target->value = dup_value;
 	target->pair_str = pair_str;
+	if (value == NULL)
+		env->export_size--;
 }

--- a/srcs/env_delete.c
+++ b/srcs/env_delete.c
@@ -49,6 +49,8 @@ static int	delete_node_by_name(t_env *env, char *name)
 	else if (target == env->tail)
 		env->tail = prev;
 	prev->next = target->next;
+	if (target->pair_str != NULL)
+		env->export_size--;
 	destroy_env_node(target);
 	env->size--;
 	return (0);

--- a/srcs/env_main.c
+++ b/srcs/env_main.c
@@ -6,11 +6,12 @@ t_env	*new_env(void)
 
 	env = (t_env *)malloc(sizeof(t_env));
 	if (env == NULL)
-		ft_fatal("malloc");
+		err_fatal(errno);
 	env->size = 0;
 	env->head = NULL;
 	env->tail = NULL;
 	env->status = 0;
+	env->export_size = 0;
 	return (env);
 }
 
@@ -20,7 +21,7 @@ t_env_node	*new_env_node(char *name, char *value, char *pair_str)
 
 	node = (t_env_node *)malloc(sizeof(t_env_node));
 	if (node == NULL)
-		ft_fatal("malloc");
+		err_fatal(errno);
 	node->name = name;
 	node->value = value;
 	node->pair_str = pair_str;
@@ -30,6 +31,8 @@ t_env_node	*new_env_node(char *name, char *value, char *pair_str)
 
 void	destroy_env(t_env *env)
 {
+	if (env == NULL)
+		return ;
 	destroy_env_nodes(env->head);
 	free(env);
 }

--- a/srcs/env_utils.c
+++ b/srcs/env_utils.c
@@ -33,10 +33,12 @@ char	*make_pair_str(char *name, char *value)
 	size_t	alloc_size;
 	char	*str;
 
+	if (value == NULL)
+		return (NULL);
 	alloc_size = ft_strlen(name) + ft_strlen(value) + 2;
 	str = (char *)malloc(sizeof(char) * alloc_size);
 	if (str == NULL)
-		ft_fatal("malloc");
+		err_fatal(errno);
 	ft_strlcpy(str, name, alloc_size);
 	ft_strlcat(str, "=", alloc_size);
 	ft_strlcat(str, value, alloc_size);
@@ -49,14 +51,15 @@ char	**env_list_to_environ(t_env *env)
 	t_env_node	*node;
 	size_t		i;
 
-	strs = (char **)malloc(sizeof(char *) * (env->size + 1));
+	strs = (char **)malloc(sizeof(char *) * (env->export_size + 1));
 	if (strs == NULL)
-		ft_fatal("malloc");
+		err_fatal(errno);
 	i = 0;
 	node = env->head;
 	while (node != NULL)
 	{
-		strs[i++] = node->pair_str;
+		if (node->pair_str != NULL)
+			strs[i++] = node->pair_str;
 		node = node->next;
 	}
 	strs[i] = NULL;

--- a/srcs/env_utils.c
+++ b/srcs/env_utils.c
@@ -43,20 +43,6 @@ char	*make_pair_str(char *name, char *value)
 	return (str);
 }
 
-void	env_print(t_env *env)
-{
-	t_env_node	*node;
-
-	if (env == NULL)
-		return ;
-	node = env->head;
-	while (node != NULL)
-	{
-		printf("%s=%s\n", node->name, node->value);
-		node = node->next;
-	}
-}
-
 char	**env_list_to_environ(t_env *env)
 {
 	char		**strs;


### PR DESCRIPTION
### 概要
- env nodeのvalueにNULLを許容する形に仕様変更。(export hoge)のような形に対応するため
- environを作成する際の、pair_strについてはvalueがNULLの場合はNULLとして追加する仕様に
- pair_strの数を管理するためのexport_sizeメンバを追加