### PR TITLE
Feat filename expansion

### DIFF
--- a/srcs/err_main.c
+++ b/srcs/err_main.c
@@ -57,3 +57,12 @@ void	err_env_name_not_valid(char *env_str)
 	ft_putstr_fd(": ", STDERR_FILENO);
 	ft_putendl_fd(ERR_INVALID_ENV_IDENT, STDERR_FILENO);
 }
+
+// bash: $foo: ambiguous redirect
+void	err_ambiguous_redirect(char *filename)
+{
+	ft_putstr_fd(ERR_PREFIX, STDERR_FILENO);
+	ft_putstr_fd(filename, STDERR_FILENO);
+	ft_putstr_fd(": ", STDERR_FILENO);
+	ft_putendl_fd(ERR_AMBIGUOUS_REDIRECT, STDERR_FILENO);
+}

--- a/srcs/ft_err.h
+++ b/srcs/ft_err.h
@@ -14,6 +14,9 @@
 # define ERR_INVALID_ENV_IDENT "not a valid identifier"
 # define ERR_SYNTAX_UNCLOSE_QUOTE "syntax error: unclosed quote"
 # define ERR_IDENT_INVALID "not a valid identifier"
+# define ERR_AMBIGUOUS_REDIRECT "ambiguous redirect"
+
+void	err_ambiguous_redirect(char *filename);
 
 // err_main.c
 void	err_puterr(char *err_msg);


### PR DESCRIPTION
## 概要
- redirect nodeのファイルリダイレクトのみexpansionを追加した
- デフォルトのIFSに含まれる文字がexpansion後の文字列に含まれていた場合は、ambiguous redirectのエラーを表示する簡易的な処理を追加している